### PR TITLE
Implemented BatchStateData

### DIFF
--- a/2d/benchmark2d.tscn
+++ b/2d/benchmark2d.tscn
@@ -1,30 +1,102 @@
-[gd_scene load_steps=4 format=3 uid="uid://dx11sgjuj2s2j"]
-
-[ext_resource type="PackedScene" uid="uid://6kqe5s0g3yc4" path="res://2d/unit.tscn" id="1_3fc77"]
-[ext_resource type="PackedScene" uid="uid://ddp6wlxjov6ll" path="res://2d/shadow.tscn" id="2_yala7"]
+[gd_scene load_steps=2 format=3 uid="uid://dx11sgjuj2s2j"]
 
 [sub_resource type="GDScript" id="GDScript_5df01"]
 script/source = "extends Control
 
-var sent_bytes: int = 0
+var unit_scene: PackedScene = preload(\"res://2d/unit.tscn\")
+var shadow_scene: PackedScene = preload(\"res://2d/shadow.tscn\")
 
+var sent_bytes: int = 0
+var send_rate: int = 30
 var _counter: float = 0.0
+var _send_rate_counter: float = 0.0
+var _use_batching: bool = false
+
+var id_counter = 1
+var shadows := Dictionary()
 
 func _ready() -> void:
 	connect_buttons()
 
-func connect_buttons() -> void:
-	$ui/b_vert.connect(\"toggled\", Callable($Unit, \"set_move_vertially\"))
-	$ui/b_hor.connect(\"toggled\", Callable($Unit, \"set_move_horizontally\"))
-	$ui/b_state.connect(\"toggled\", Callable($Unit, \"set_change_state\"))
-	$ui/b_rotation.connect(\"toggled\", Callable($Unit, \"apply_rotation\"))
-	$ui/b_packet_count/spinbox.connect(\"value_changed\", Callable($Unit, \"set_send_rate\"))
+func spawn_object() -> void:
+	add_unit(id_counter)
+	add_shadow(id_counter)
+	id_counter += 1
 
-func on_change_state_pressed(toggled: bool) -> void:
-	$Unit.changes_state = toggled
+func add_unit(id: int = id_counter) -> void:
+	var new_unit = unit_scene.instantiate()
+	new_unit.id = id
+	new_unit.position.x = 256.0 + randi_range(-200, 200)
+	new_unit.position.y = 360 + randi_range(-200, 200)
+	add_child(new_unit)
+
+func add_shadow(id: int = id_counter) -> void:
+	var new_shadow = shadow_scene.instantiate()
+	new_shadow.id = id_counter
+	add_child(new_shadow)
+
+func connect_buttons() -> void:
+	$ui/b_add.connect(\"pressed\", Callable(self, \"spawn_object\"))
+	$ui/b_batch.connect(\"toggled\", Callable(self, \"set_use_batching\"))
+	$ui/b_vert.connect(\"toggled\", Callable(self, \"set_move_vertically\"))
+	$ui/b_hor.connect(\"toggled\", Callable(self, \"set_move_horizontally\"))
+	$ui/b_state.connect(\"toggled\", Callable(self, \"set_change_state\"))
+	$ui/b_rotation.connect(\"toggled\", Callable(self, \"apply_rotation\"))
+	$ui/b_packet_count/spinbox.connect(\"value_changed\", Callable(self, \"set_send_rate\"))
+
+func set_use_batching(val: bool):
+	_use_batching = val
+
+func set_change_state(val: bool) -> void:
+	for node in get_tree().get_nodes_in_group(\"unit\"):
+		node.set_change_state(val)
+
+func apply_rotation(val: bool) -> void:
+	for node in get_tree().get_nodes_in_group(\"unit\"):
+		node.apply_rotation(val)
+
+func set_move_vertically(val: bool) -> void:
+	for node in get_tree().get_nodes_in_group(\"unit\"):
+		node.set_move_vertically(val)
+
+func set_move_horizontally(val: bool) -> void:
+	for node in get_tree().get_nodes_in_group(\"unit\"):
+		node.set_move_horizontally(val)
+
+func set_send_rate(val: int) -> void:
+	send_rate = val
 
 func _process(delta: float) -> void:
+	process_state_sync(delta)
 	process_send_rate(delta)
+
+func process_state_sync(delta: float) -> void:
+	_send_rate_counter += delta
+	if _send_rate_counter > 1.0 / float(send_rate):
+		_send_rate_counter = 0.0
+		var batch_data: Dictionary[int, StateData] = {}
+		for node in get_tree().get_nodes_in_group(\"unit\"):
+			var packet = node.get_packet()
+			if packet:
+				if _use_batching:
+					batch_data[node.id] = packet
+					var batch_packet = BatchStateData2D.new(batch_data)
+					var batch_bytes = batch_packet.to_bytes()
+					add_sent_bytes(batch_bytes.size())
+					on_receive_batch(batch_bytes)
+				else:
+					var byte_array: PackedByteArray = packet.to_bytes()
+					add_sent_bytes(byte_array.size())
+					var shadow = get_shadow(node.id)
+					shadow.on_receive_packet(byte_array)
+
+func on_receive_batch(bytes: PackedByteArray) -> void:
+	var batch = BatchStateData2D.from_bytes(bytes)
+	for key in batch.get_data().keys():
+		var shadow = get_shadow(key)
+		if shadow:
+			var state_data: StateData = batch.get_data()[key]
+			shadow.sync_state(state_data)
 
 func process_send_rate(delta: float) -> void:
 	_counter += delta
@@ -39,6 +111,15 @@ func add_sent_bytes(amount: int) -> void:
 
 func get_sent_bits() -> int:
 	return sent_bytes * 8
+
+func get_shadow(id: int) -> Node2D:
+	if shadows.has(id):
+		return shadows[id]
+	for node in get_tree().get_nodes_in_group(\"shadow\"):
+		if node.id == id:
+			shadows[id] = node
+			return node
+	return null
 "
 
 [node name="benchmark" type="Control"]
@@ -67,6 +148,16 @@ text = "kbits/sec"
 [node name="vsep" type="VSeparator" parent="ui"]
 layout_mode = 2
 
+[node name="b_add" type="Button" parent="ui"]
+layout_mode = 2
+text = "Add unit"
+
+[node name="b_batch" type="Button" parent="ui"]
+layout_mode = 2
+focus_mode = 0
+toggle_mode = true
+text = "Use batching"
+
 [node name="b_vert" type="Button" parent="ui"]
 layout_mode = 2
 focus_mode = 0
@@ -92,9 +183,6 @@ toggle_mode = true
 text = "Apply Rotation
 "
 
-[node name="vsep2" type="VSeparator" parent="ui"]
-layout_mode = 2
-
 [node name="b_packet_count" type="HBoxContainer" parent="ui"]
 layout_mode = 2
 
@@ -105,12 +193,3 @@ text = "packets/sec"
 [node name="spinbox" type="SpinBox" parent="ui/b_packet_count"]
 layout_mode = 2
 value = 30.0
-
-[node name="Unit" parent="." instance=ExtResource("1_3fc77")]
-position = Vector2(276, 259)
-
-[node name="shadow" parent="." instance=ExtResource("2_yala7")]
-modulate = Color(1, 1, 1, 1)
-self_modulate = Color(1, 1, 1, 0.596078)
-position = Vector2(276, 259)
-scale = Vector2(0.5, 0.5)

--- a/2d/benchmark2d.tscn
+++ b/2d/benchmark2d.tscn
@@ -85,6 +85,7 @@ func set_send_rate(val: int) -> void:
 func _process(delta: float) -> void:
 	process_state_sync(delta)
 	process_send_rate(delta)
+	$ui/units.text = \"units: %d\" % (id_counter)
 
 func process_state_sync(delta: float) -> void:
 	_send_rate_counter += delta
@@ -168,6 +169,11 @@ columns = 10
 custom_minimum_size = Vector2(128, 0)
 layout_mode = 2
 text = "kbits/sec"
+
+[node name="units" type="Label" parent="ui"]
+custom_minimum_size = Vector2(128, 0)
+layout_mode = 2
+text = "units: 0"
 
 [node name="vsep" type="VSeparator" parent="ui"]
 layout_mode = 2

--- a/2d/benchmark2d.tscn
+++ b/2d/benchmark2d.tscn
@@ -12,7 +12,7 @@ var _counter: float = 0.0
 var _send_rate_counter: float = 0.0
 var _use_batching: bool = false
 
-var id_counter = 1
+var id_counter = 0
 var shadows := Dictionary()
 
 func _ready() -> void:
@@ -23,12 +23,27 @@ func spawn_object() -> void:
 	add_shadow(id_counter)
 	id_counter += 1
 
+func despawn_object() -> void:
+	if id_counter > 0:
+		id_counter -= 1
+		var unit = get_unit(id_counter)
+		var shadow = get_shadow(id_counter)
+		shadows.erase(id_counter)
+		unit.queue_free()
+		shadow.queue_free()
+
 func add_unit(id: int = id_counter) -> void:
 	var new_unit = unit_scene.instantiate()
 	new_unit.id = id
 	new_unit.position.x = 256.0 + randi_range(-200, 200)
 	new_unit.position.y = 360 + randi_range(-200, 200)
 	add_child(new_unit)
+	if id > 0:
+		var root_unit = get_unit(0)
+		new_unit.set_change_state(root_unit.changes_state)
+		new_unit.apply_rotation(root_unit.get(\"_angle\") > 0.0)
+		new_unit.set_move_vertically(root_unit.move_vertially)
+		new_unit.set_move_horizontally(root_unit.move_horizontally)
 
 func add_shadow(id: int = id_counter) -> void:
 	var new_shadow = shadow_scene.instantiate()
@@ -37,6 +52,7 @@ func add_shadow(id: int = id_counter) -> void:
 
 func connect_buttons() -> void:
 	$ui/b_add.connect(\"pressed\", Callable(self, \"spawn_object\"))
+	$ui/b_remove.connect(\"pressed\", Callable(self, \"despawn_object\"))
 	$ui/b_batch.connect(\"toggled\", Callable(self, \"set_use_batching\"))
 	$ui/b_vert.connect(\"toggled\", Callable(self, \"set_move_vertically\"))
 	$ui/b_hor.connect(\"toggled\", Callable(self, \"set_move_horizontally\"))
@@ -114,6 +130,12 @@ func add_sent_bytes(amount: int) -> void:
 func get_sent_bits() -> int:
 	return sent_bytes * 8
 
+func get_unit(id: int) -> Node2D:
+	for node in get_tree().get_nodes_in_group(\"unit\"):
+		if node.id == id:
+			return node
+	return null
+
 func get_shadow(id: int) -> Node2D:
 	if shadows.has(id):
 		return shadows[id]
@@ -140,7 +162,7 @@ anchor_right = 1.0
 offset_bottom = 82.0
 grow_horizontal = 2
 size_flags_horizontal = 4
-columns = 8
+columns = 10
 
 [node name="bps" type="Label" parent="ui"]
 custom_minimum_size = Vector2(128, 0)
@@ -149,10 +171,15 @@ text = "kbits/sec"
 
 [node name="vsep" type="VSeparator" parent="ui"]
 layout_mode = 2
+size_flags_horizontal = 0
 
 [node name="b_add" type="Button" parent="ui"]
 layout_mode = 2
 text = "Add unit"
+
+[node name="b_remove" type="Button" parent="ui"]
+layout_mode = 2
+text = "Remove unit"
 
 [node name="b_batch" type="Button" parent="ui"]
 layout_mode = 2

--- a/2d/benchmark2d.tscn
+++ b/2d/benchmark2d.tscn
@@ -80,15 +80,16 @@ func process_state_sync(delta: float) -> void:
 			if packet:
 				if _use_batching:
 					batch_data[node.id] = packet
-					var batch_packet = BatchStateData2D.new(batch_data)
-					var batch_bytes = batch_packet.to_bytes()
-					add_sent_bytes(batch_bytes.size())
-					on_receive_batch(batch_bytes)
 				else:
 					var byte_array: PackedByteArray = packet.to_bytes()
 					add_sent_bytes(byte_array.size())
 					var shadow = get_shadow(node.id)
 					shadow.on_receive_packet(byte_array)
+		if not batch_data.is_empty():
+			var batch_packet = BatchStateData2D.new(batch_data)
+			var batch_bytes = batch_packet.to_bytes()
+			add_sent_bytes(batch_bytes.size())
+			on_receive_batch(batch_bytes)
 
 func on_receive_batch(bytes: PackedByteArray) -> void:
 	var batch = BatchStateData2D.from_bytes(bytes)
@@ -107,7 +108,8 @@ func process_send_rate(delta: float) -> void:
 		_counter = 0.0
 
 func add_sent_bytes(amount: int) -> void:
-	sent_bytes += amount
+	var udp_header = 8 # 64 bit udp header
+	sent_bytes += udp_header + amount
 
 func get_sent_bits() -> int:
 	return sent_bytes * 8

--- a/2d/shadow.tscn
+++ b/2d/shadow.tscn
@@ -14,11 +14,15 @@ var states: Dictionary = {
 	5: Color.PINK
 }
 
+var id: int = 0
+
 var state: int = 0 : set = set_state
 
 func on_receive_packet(packet: PackedByteArray) -> void:
-	
 	var state_data: StateData = StateData2D.from_bytes(packet)
+	sync_state(state_data)
+
+func sync_state(state_data: StateData) -> void:
 	
 	var pos_x = null
 	var pos_y = null
@@ -51,7 +55,9 @@ func set_state(new_state: int) -> void:
 	modulate = states[new_state]
 "
 
-[node name="shadow" type="Sprite2D"]
+[node name="shadow" type="Sprite2D" groups=["shadow"]]
 modulate = Color(1, 1, 1, 0.596078)
+self_modulate = Color(1, 1, 1, 0.529412)
+scale = Vector2(0.5, 0.5)
 texture = ExtResource("1_6pqxc")
 script = SubResource("GDScript_6pqxc")

--- a/2d/unit.tscn
+++ b/2d/unit.tscn
@@ -81,17 +81,6 @@ func process_states(delta: float) -> void:
 			_counter = 0.0
 			change_state()
 
-## DEPRECATED function
-func process_state_sync(delta: float) -> void:
-	_counter2 += delta
-	if _counter2 > 1.0 / float(_send_rate):
-		_counter2 = 0.0
-		
-		var packet = get_packet()
-		
-		if packet.has_data():
-			send_packet(packet)
-
 func get_packet() -> Variant:
 	var packet = StateData2D.new()
 	if state != last_state:
@@ -110,11 +99,6 @@ func get_packet() -> Variant:
 	if packet.has_data():
 		return packet
 	return null
-
-func send_packet(packet: StateData) -> void:
-	var byte_array: PackedByteArray = packet.to_bytes()
-	get_parent().add_sent_bytes(byte_array.size())
-	get_parent().get_node(\"shadow\").on_receive_packet(byte_array)
 
 func process_movement(delta: float) -> void:
 	

--- a/2d/unit.tscn
+++ b/2d/unit.tscn
@@ -14,6 +14,8 @@ var states: Dictionary = {
 	5: Color.PINK
 }
 
+var id: int = 0
+
 var movement_area = Vector2(1270, 720)
 var move_dir = Vector2(0, 0)
 var move_speed = 250
@@ -54,7 +56,7 @@ func set_change_state(val: bool) -> void:
 func apply_rotation(val: bool) -> void:
 	_angle = randf_range(1.0, 10.0) if val else 0.0
 
-func set_move_vertially(val: bool) -> void:
+func set_move_vertically(val: bool) -> void:
 	move_dir.y = randf_range(-1.0, 1.0) if val else 0.0
 	move_dir = move_dir.normalized()
 	move_vertially = val
@@ -69,7 +71,6 @@ func set_send_rate(val: int) -> void:
 
 func _process(delta: float) -> void:
 	process_states(delta)
-	process_state_sync(delta)
 	process_movement(delta)
 	process_rotation(delta)
 
@@ -80,28 +81,35 @@ func process_states(delta: float) -> void:
 			_counter = 0.0
 			change_state()
 
+## DEPRECATED function
 func process_state_sync(delta: float) -> void:
 	_counter2 += delta
 	if _counter2 > 1.0 / float(_send_rate):
 		_counter2 = 0.0
 		
-		var packet = StateData2D.new()
-		
-		if state != last_state:
-			packet.append(StateData2D.STATE, state)
-			last_state = state
-		if position.x != last_pos_x:
-			packet.append(StateData2D.POS_X, position.x)
-			last_pos_x = position.x
-		if position.y != last_pos_y:
-			packet.append(StateData2D.POS_Y, position.y)
-			last_pos_y = position.y
-		if rotation != last_rot:
-			packet.append(StateData2D.ROT, rotation)
-			last_rot = rotation
+		var packet = get_packet()
 		
 		if packet.has_data():
 			send_packet(packet)
+
+func get_packet() -> Variant:
+	var packet = StateData2D.new()
+	if state != last_state:
+		packet.append(StateData2D.STATE, state)
+		last_state = state
+	if position.x != last_pos_x:
+		packet.append(StateData2D.POS_X, position.x)
+		last_pos_x = position.x
+	if position.y != last_pos_y:
+		packet.append(StateData2D.POS_Y, position.y)
+		last_pos_y = position.y
+	if rotation != last_rot:
+		packet.append(StateData2D.ROT, rotation)
+		last_rot = rotation
+
+	if packet.has_data():
+		return packet
+	return null
 
 func send_packet(packet: StateData) -> void:
 	var byte_array: PackedByteArray = packet.to_bytes()
@@ -124,7 +132,7 @@ func process_rotation(delta: float) -> void:
 			rotation -= 360
 "
 
-[node name="Unit" type="Sprite2D"]
+[node name="Unit" type="Sprite2D" groups=["unit"]]
 scale = Vector2(0.5, 0.5)
 texture = ExtResource("1_btf8p")
 script = SubResource("GDScript_btf8p")

--- a/3d/benchmark3d.tscn
+++ b/3d/benchmark3d.tscn
@@ -1,34 +1,140 @@
-[gd_scene load_steps=4 format=3 uid="uid://deej8r8b345l4"]
-
-[ext_resource type="PackedScene" uid="uid://6obhswiy5rre" path="res://3d/unit3d.tscn" id="1_kujka"]
-[ext_resource type="PackedScene" uid="uid://1smt4uyggw43" path="res://3d/shadow3d.tscn" id="2_oqfq0"]
+[gd_scene load_steps=2 format=3 uid="uid://ccataafcggfki"]
 
 [sub_resource type="GDScript" id="GDScript_5df01"]
 script/source = "extends Control
 
-var sent_bytes: int = 0
+var unit_scene: PackedScene = preload(\"res://3d/unit.tscn\")
+var shadow_scene: PackedScene = preload(\"res://3d/shadow.tscn\")
 
+var sent_bytes: int = 0
+var send_rate: int = 30
 var _counter: float = 0.0
+var _send_rate_counter: float = 0.0
+var _use_batching: bool = false
+
+var id_counter = 0
+var shadows := Dictionary()
 
 func _ready() -> void:
 	connect_buttons()
 
-func connect_buttons() -> void:
-	$ui/b_vert.connect(\"toggled\", Callable($world/Unit, \"set_move_vertially\"))
-	$ui/b_hor.connect(\"toggled\", Callable($world/Unit, \"set_move_horizontally\"))
-	$ui/b_depth.connect(\"toggled\", Callable($world/Unit, \"set_move_depthwise\"))
-	$ui/b_state.connect(\"toggled\", Callable($world/Unit, \"set_change_state\"))
-	$ui/b_rot_x.connect(\"toggled\", Callable($world/Unit, \"apply_rotation_x\"))
-	$ui/b_rot_y.connect(\"toggled\", Callable($world/Unit, \"apply_rotation_y\"))
-	$ui/b_rot_z.connect(\"toggled\", Callable($world/Unit, \"apply_rotation_z\"))
-	
-	$ui/b_packet_count/spinbox.connect(\"value_changed\", Callable($world/Unit, \"set_send_rate\"))
+func spawn_object() -> void:
+	add_unit(id_counter)
+	add_shadow(id_counter)
+	id_counter += 1
 
-func on_change_state_pressed(toggled: bool) -> void:
-	$Unit.changes_state = toggled
+func despawn_object() -> void:
+	if id_counter > 0:
+		id_counter -= 1
+		var unit = get_unit(id_counter)
+		var shadow = get_shadow(id_counter)
+		shadows.erase(id_counter)
+		unit.queue_free()
+		shadow.queue_free()
+
+func add_unit(id: int = id_counter) -> void:
+	var new_unit = unit_scene.instantiate()
+	new_unit.id = id
+	new_unit.position.x = 2 + randi_range(-2, 2)
+	new_unit.position.y = randi_range(-2, 2)
+	new_unit.position.z = randi_range(-2, 2)
+	
+	$world.add_child(new_unit)
+	if id > 0:
+		var root_unit = get_unit(0)
+		new_unit.set_change_state(root_unit.changes_state)
+		new_unit.apply_rotation_x(root_unit.get(\"_angle_x\") > 0.0)
+		new_unit.apply_rotation_y(root_unit.get(\"_angle_y\") > 0.0)
+		new_unit.apply_rotation_z(root_unit.get(\"_angle_z\") > 0.0)
+		new_unit.set_move_vertically(root_unit.move_vertially)
+		new_unit.set_move_horizontally(root_unit.move_horizontally)
+		new_unit.set_move_depthwise(root_unit.move_depthwise)
+
+func add_shadow(id: int = id_counter) -> void:
+	var new_shadow = shadow_scene.instantiate()
+	new_shadow.id = id_counter
+	$world.add_child(new_shadow)
+
+func connect_buttons() -> void:
+	$ui/b_add.connect(\"pressed\", Callable(self, \"spawn_object\"))
+	$ui/b_remove.connect(\"pressed\", Callable(self, \"despawn_object\"))
+	$ui/b_batch.connect(\"toggled\", Callable(self, \"set_use_batching\"))
+	$ui/b_vert.connect(\"toggled\", Callable(self, \"set_move_vertically\"))
+	$ui/b_hor.connect(\"toggled\", Callable(self, \"set_move_horizontally\"))
+	$ui/b_depth.connect(\"toggled\", Callable(self, \"set_move_depthwise\"))
+	$ui/b_state.connect(\"toggled\", Callable(self, \"set_change_state\"))
+	$ui/b_rot_x.connect(\"toggled\", Callable(self, \"apply_rotation_x\"))
+	$ui/b_rot_y.connect(\"toggled\", Callable(self, \"apply_rotation_y\"))
+	$ui/b_rot_z.connect(\"toggled\", Callable(self, \"apply_rotation_z\"))
+	$ui/b_packet_count/spinbox.connect(\"value_changed\", Callable(self, \"set_send_rate\"))
+
+func set_use_batching(val: bool):
+	_use_batching = val
+
+func set_change_state(val: bool) -> void:
+	for node in get_tree().get_nodes_in_group(\"unit\"):
+		node.set_change_state(val)
+
+func apply_rotation_x(val: bool) -> void:
+	for node in get_tree().get_nodes_in_group(\"unit\"):
+		node.apply_rotation_x(val)
+
+func apply_rotation_y(val: bool) -> void:
+	for node in get_tree().get_nodes_in_group(\"unit\"):
+		node.apply_rotation_y(val)
+
+func apply_rotation_z(val: bool) -> void:
+	for node in get_tree().get_nodes_in_group(\"unit\"):
+		node.apply_rotation_z(val)
+
+func set_move_vertically(val: bool) -> void:
+	for node in get_tree().get_nodes_in_group(\"unit\"):
+		node.set_move_vertically(val)
+
+func set_move_horizontally(val: bool) -> void:
+	for node in get_tree().get_nodes_in_group(\"unit\"):
+		node.set_move_horizontally(val)
+
+func set_move_depthwise(val: bool) -> void:
+	for node in get_tree().get_nodes_in_group(\"unit\"):
+		node.set_move_depthwise(val)
+
+func set_send_rate(val: int) -> void:
+	send_rate = val
 
 func _process(delta: float) -> void:
+	$ui/units.text = \"units: %d\" % (id_counter)
+	process_state_sync(delta)
 	process_send_rate(delta)
+
+func process_state_sync(delta: float) -> void:
+	_send_rate_counter += delta
+	if _send_rate_counter > 1.0 / float(send_rate):
+		_send_rate_counter = 0.0
+		var batch_data: Dictionary[int, StateData] = {}
+		for node in get_tree().get_nodes_in_group(\"unit\"):
+			var packet = node.get_packet()
+			if packet:
+				if _use_batching:
+					batch_data[node.id] = packet
+				else:
+					var byte_array: PackedByteArray = packet.to_bytes()
+					add_sent_bytes(byte_array.size())
+					var shadow = get_shadow(node.id)
+					shadow.on_receive_packet(byte_array)
+		if not batch_data.is_empty():
+			var batch_packet = BatchStateData2D.new(batch_data)
+			var batch_bytes = batch_packet.to_bytes()
+			add_sent_bytes(batch_bytes.size())
+			on_receive_batch(batch_bytes)
+
+func on_receive_batch(bytes: PackedByteArray) -> void:
+	var batch = BatchStateData3D.from_bytes(bytes)
+	for key in batch.get_data().keys():
+		var shadow = get_shadow(key)
+		if shadow:
+			var state_data: StateData = batch.get_data()[key]
+			shadow.sync_state(state_data)
 
 func process_send_rate(delta: float) -> void:
 	_counter += delta
@@ -39,10 +145,26 @@ func process_send_rate(delta: float) -> void:
 		_counter = 0.0
 
 func add_sent_bytes(amount: int) -> void:
-	sent_bytes += amount
+	var udp_header = 8 # 64 bit udp header
+	sent_bytes += udp_header + amount
 
 func get_sent_bits() -> int:
 	return sent_bytes * 8
+
+func get_unit(id: int) -> Node3D:
+	for node in get_tree().get_nodes_in_group(\"unit\"):
+		if node.id == id:
+			return node
+	return null
+
+func get_shadow(id: int) -> Node3D:
+	if shadows.has(id):
+		return shadows[id]
+	for node in get_tree().get_nodes_in_group(\"shadow\"):
+		if node.id == id:
+			shadows[id] = node
+			return node
+	return null
 "
 
 [node name="benchmark" type="Control"]
@@ -61,33 +183,52 @@ anchor_right = 1.0
 offset_bottom = 82.0
 grow_horizontal = 2
 size_flags_horizontal = 4
-columns = 8
+columns = 13
 
 [node name="bps" type="Label" parent="ui"]
 custom_minimum_size = Vector2(128, 0)
 layout_mode = 2
 text = "kbits/sec"
 
+[node name="units" type="Label" parent="ui"]
+custom_minimum_size = Vector2(128, 0)
+layout_mode = 2
+text = "units: 0"
+
 [node name="vsep" type="VSeparator" parent="ui"]
 layout_mode = 2
+
+[node name="b_add" type="Button" parent="ui"]
+layout_mode = 2
+text = "Add unit"
+
+[node name="b_remove" type="Button" parent="ui"]
+layout_mode = 2
+text = "Remove unit"
+
+[node name="b_batch" type="Button" parent="ui"]
+layout_mode = 2
+focus_mode = 0
+toggle_mode = true
+text = "Use batching"
 
 [node name="b_vert" type="Button" parent="ui"]
 layout_mode = 2
 focus_mode = 0
 toggle_mode = true
-text = "Move vertically"
+text = "Move Y"
 
 [node name="b_hor" type="Button" parent="ui"]
 layout_mode = 2
 focus_mode = 0
 toggle_mode = true
-text = "Move horizontally"
+text = "Move X"
 
 [node name="b_depth" type="Button" parent="ui"]
 layout_mode = 2
 focus_mode = 0
 toggle_mode = true
-text = "Move depthwise"
+text = "Move Z"
 
 [node name="b_state" type="Button" parent="ui"]
 layout_mode = 2
@@ -115,9 +256,6 @@ focus_mode = 0
 toggle_mode = true
 text = "Rot Z"
 
-[node name="vsep2" type="VSeparator" parent="ui"]
-layout_mode = 2
-
 [node name="b_packet_count" type="HBoxContainer" parent="ui"]
 layout_mode = 2
 
@@ -134,12 +272,6 @@ value = 30.0
 [node name="Camera3D" type="Camera3D" parent="world"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 7.99024)
 current = true
-
-[node name="Unit" parent="world" instance=ExtResource("1_kujka")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2, 0, 0)
-
-[node name="shadow" parent="world" instance=ExtResource("2_oqfq0")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2, 0, 0)
 
 [node name="DirectionalLight3D" type="DirectionalLight3D" parent="world"]
 transform = Transform3D(0.981019, 0, -0.193909, 0, 1, 0, 0.193909, 0, 0.981019, -4.45038, 0, 0)

--- a/3d/shadow.tscn
+++ b/3d/shadow.tscn
@@ -11,12 +11,14 @@ var states: Dictionary = {
 	4: Color.YELLOW,
 	5: Color.PINK
 }
-
+var id: int = 0
 var state: int = 0 : set = set_state
 
 func on_receive_packet(packet: PackedByteArray) -> void:
 	var state_data: StateData = StateData3D.from_bytes(packet)
-	
+	sync_state(state_data)
+
+func sync_state(state_data: StateData) -> void:
 	var pos_x = null
 	var pos_y = null
 	var pos_z = null

--- a/3d/shadow.tscn
+++ b/3d/shadow.tscn
@@ -72,7 +72,7 @@ albedo_color = Color(1, 1, 1, 0.8)
 [sub_resource type="BoxMesh" id="BoxMesh_gt6dh"]
 material = SubResource("StandardMaterial3D_shm6d")
 
-[node name="shadow" type="Node3D"]
+[node name="shadow" type="Node3D" groups=["shadow"]]
 script = SubResource("GDScript_shm6d")
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="."]

--- a/3d/unit.tscn
+++ b/3d/unit.tscn
@@ -158,7 +158,7 @@ func process_rotation(delta: float) -> void:
 [sub_resource type="BoxMesh" id="BoxMesh_3wnp8"]
 material = SubResource("StandardMaterial3D_3wnp8")
 
-[node name="Unit3d" type="Node3D"]
+[node name="Unit3d" type="Node3D" groups=["unit"]]
 script = SubResource("GDScript_3wnp8")
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="."]

--- a/3d/unit.tscn
+++ b/3d/unit.tscn
@@ -12,6 +12,8 @@ var states: Dictionary = {
 	5: Color.PINK
 }
 
+var id: int = 0
+
 var movement_area = Vector3(4, 4, 4)
 var move_dir = Vector3(0, 0, 0)
 var move_speed = 2
@@ -60,7 +62,7 @@ func apply_rotation_y(val: bool) -> void:
 func apply_rotation_z(val: bool) -> void:
 	_angle_z = randf_range(1.0, 10.0) if val else 0.0
 
-func set_move_vertially(val: bool) -> void:
+func set_move_vertically(val: bool) -> void:
 	move_dir.y = randf_range(-1.0, 1.0) if val else 0.0
 	move_dir = move_dir.normalized()
 	move_vertially = val
@@ -80,7 +82,6 @@ func set_send_rate(val: int) -> void:
 
 func _process(delta: float) -> void:
 	process_states(delta)
-	process_state_sync(delta)
 	process_movement(delta)
 	process_rotation(delta)
 
@@ -91,38 +92,30 @@ func process_states(delta: float) -> void:
 			_counter = 0.0
 			change_state()
 
-func process_state_sync(delta: float) -> void:
-	_counter2 += delta
-	if _counter2 > 1.0 / float(_send_rate):
-		_counter2 = 0.0
+func get_packet() -> Variant:
+	var packet = StateData3D.new()
+	
+	var values = [state, position.x, position.y, position.z,
+		rotation.x, rotation.y, rotation.z]
+	
+	var indicies = [StateData3D.STATE, StateData3D.POS_X, StateData3D.POS_Y,
+		StateData3D.POS_Z, StateData3D.ROT_X, StateData3D.ROT_Y, StateData3D.ROT_Z]
+	
+	var last_values = [\"last_state\", \"last_pos_x\", \"last_pos_y\", \"last_pos_z\",
+		\"last_rot_x\", \"last_rot_y\", \"last_rot_z\"]
+	
+	for i in range(values.size()):
+		var val = values[i]
+		var index = indicies[i]
+		var last_val = last_values[i]
 		
-		var packet = StateData3D.new()
-		
-		var values = [state, position.x, position.y, position.z,
-			rotation.x, rotation.y, rotation.z]
-		
-		var indicies = [StateData3D.STATE, StateData3D.POS_X, StateData3D.POS_Y,
-			StateData3D.POS_Z, StateData3D.ROT_X, StateData3D.ROT_Y, StateData3D.ROT_Z]
-		
-		var last_values = [\"last_state\", \"last_pos_x\", \"last_pos_y\", \"last_pos_z\",
-			\"last_rot_x\", \"last_rot_y\", \"last_rot_z\"]
-		
-		for i in range(values.size()):
-			var val = values[i]
-			var index = indicies[i]
-			var last_val = last_values[i]
-			
-			if val != get(last_val):
-				packet.append(index, val)
-				set(last_val, val)
-		
-		if packet.has_data():
-			send_packet(packet)
+		if val != get(last_val):
+			packet.append(index, val)
+			set(last_val, val)
 
-func send_packet(packet: StateData) -> void:
-	var byte_array: PackedByteArray = packet.to_bytes()
-	get_parent().get_parent().add_sent_bytes(byte_array.size())
-	get_parent().get_node(\"shadow\").on_receive_packet(byte_array)
+	if packet.has_data():
+		return packet
+	return null
 
 func process_movement(delta: float) -> void:
 	
@@ -158,7 +151,7 @@ func process_rotation(delta: float) -> void:
 [sub_resource type="BoxMesh" id="BoxMesh_3wnp8"]
 material = SubResource("StandardMaterial3D_3wnp8")
 
-[node name="Unit3d" type="Node3D" groups=["unit"]]
+[node name="unit" type="Node3D" groups=["unit"]]
 script = SubResource("GDScript_3wnp8")
 
 [node name="MeshInstance3D" type="MeshInstance3D" parent="."]

--- a/BatchStateData.gd
+++ b/BatchStateData.gd
@@ -1,0 +1,32 @@
+class_name BatchStateData
+
+var _states: Array[StateData]
+
+func _init(states: Array[StateData]) -> void:
+	_states = states
+
+func to_bytes() -> PackedByteArray:
+	var buffer := StreamPeerBuffer.new()
+	
+	buffer.put_u8(_states.size()) # Write the amount of StateDatas encoded in this byte array
+	
+	# TODO write each state to buffer and the respective node id
+	
+	return buffer.data_array
+
+static func from_bytes(bytes: PackedByteArray) -> BatchStateData:
+	var buffer := StreamPeerBuffer.new()
+	buffer.data_array = bytes
+	
+	var array: Array[StateData] = []
+	
+	var encoded_state_count = buffer.get_u8()
+	
+	# TODO read each state from the buffer
+	
+	for i in range(encoded_state_count):
+		pass
+	return BatchStateData.new(array)
+
+func get_states() -> Array[StateData]:
+	return _states

--- a/BatchStateData.gd
+++ b/BatchStateData.gd
@@ -1,32 +1,55 @@
 class_name BatchStateData
+## Base class for batched state data encoding.
+##
+## A compact data structure for encoding multiple
+## StateData objects for efficient network transmission.
 
-var _states: Array[StateData]
+## Contains [StateData] and key pairs.
+var _data: Dictionary[int, StateData] # key: int, value: StateData
 
-func _init(states: Array[StateData]) -> void:
-	_states = states
+## Initializes a new [BatchStateData] object with the values in [param data].
+func _init(data: Dictionary[int, StateData] = {}) -> void:
+	_data = data
 
+## Returns this [BatchStateData] object as a [PackedByteArray].
 func to_bytes() -> PackedByteArray:
 	var buffer := StreamPeerBuffer.new()
 	
-	buffer.put_u8(_states.size()) # Write the amount of StateDatas encoded in this byte array
+	buffer.put_u8(_data.size()) # Write the amount of StateDatas encoded in this byte array
 	
-	# TODO write each state to buffer and the respective node id
+	for key in _data.keys():
+		var state = _data[key]
+		var data = state.to_bytes()
+		buffer.put_u16(key) # write the key to buffer
+		buffer.put_data(data) # write StateData as byte array to buffer
 	
 	return buffer.data_array
 
-static func from_bytes(bytes: PackedByteArray) -> BatchStateData:
+## Returns a new [BatchStateData] object from [param bytes] passed as an argument.
+static func from_bytes(bytes: PackedByteArray, encoded_bits: int = 4) -> BatchStateData:
 	var buffer := StreamPeerBuffer.new()
 	buffer.data_array = bytes
 	
-	var array: Array[StateData] = []
-	
+	var data: Dictionary[int, StateData] = {}
 	var encoded_state_count = buffer.get_u8()
 	
-	# TODO read each state from the buffer
-	
 	for i in range(encoded_state_count):
-		pass
-	return BatchStateData.new(array)
+		var key = buffer.get_u16()
+		var state = get_state(buffer, encoded_bits)
+		data.set(key, state)
+		
+	return BatchStateData.new(data)
 
-func get_states() -> Array[StateData]:
-	return _states
+## Reads state data from [param buffer] and returns it as an [StateData] object.
+static func get_state(buffer: StreamPeerBuffer, encoded_bits: int) -> StateData:
+	var data: Array = []
+	var map: PackedInt32Array = StateData.bits_to_map(buffer.get_u8(), encoded_bits)
+	for i in map:
+		var val: Variant = StateData.value_from_bytes(buffer, i)
+		data.append(val)
+	
+	return StateData.new(data, map, encoded_bits)
+
+## Returns [member _data] attribute of this [BatchStateData].
+func get_data() -> Dictionary[int, StateData]:
+	return _data

--- a/BatchStateData.gd.uid
+++ b/BatchStateData.gd.uid
@@ -1,0 +1,1 @@
+uid://dfmnubyj85abq

--- a/BatchStateData2D.gd
+++ b/BatchStateData2D.gd
@@ -1,0 +1,14 @@
+class_name BatchStateData2D
+extends BatchStateData
+## 2D implementation of the [BatchStateData] class.
+##
+## A compact data structure for efficiently encoding multiple [StateData2D]
+## objects as a [PackedByteArray] for low bandwith network transmission.
+
+## Initializes a new [BatchStateData2D] object with the values in [param data].
+func _init(data: Dictionary[int, StateData] = {}) -> void:
+	super._init(data)
+
+## Returns a new [BatchStateData] object from [param bytes] passed as an argument.
+static func from_bytes(bytes: PackedByteArray, encoded_bits: int = StateData2D.ENCODED_BITS) -> BatchStateData:
+	return super.from_bytes(bytes, encoded_bits)

--- a/BatchStateData2D.gd.uid
+++ b/BatchStateData2D.gd.uid
@@ -1,0 +1,1 @@
+uid://bbu6653rrwwpp

--- a/BatchStateData3D.gd
+++ b/BatchStateData3D.gd
@@ -1,0 +1,14 @@
+class_name BatchStateData3D
+extends BatchStateData
+## 3D implementation of the [BatchStateData] class.
+##
+## A compact data structure for efficiently encoding multiple [StateData3D]
+## objects as a [PackedByteArray] for low bandwith network transmission.
+
+## Initializes a new [BatchStateData3D] object with the values in [param data].
+func _init(data: Dictionary[int, StateData] = {}) -> void:
+	super._init(data)
+
+## Returns a new [BatchStateData] object from [param bytes] passed as an argument.
+static func from_bytes(bytes: PackedByteArray, encoded_bits: int = StateData3D.ENCODED_BITS) -> BatchStateData:
+	return super.from_bytes(bytes, encoded_bits)

--- a/BatchStateData3D.gd.uid
+++ b/BatchStateData3D.gd.uid
@@ -1,0 +1,1 @@
+uid://c7q8jcqptnh77

--- a/StateData.gd
+++ b/StateData.gd
@@ -44,6 +44,9 @@ func append(index: int, value: Variant):
 	_map.append(index)
 	_data.append(value)
 
+func equals(state: StateData) -> bool:
+	return _data == state.get_data() and _map == state.get_map()
+
 ## Returns true if [member StateDate.data] contains at least an element.
 func has_data() -> bool:
 	return not _data.is_empty()
@@ -80,15 +83,19 @@ static func from_bytes(bytes: PackedByteArray, encoded_bits: int = 4) -> StateDa
 	var decoded_map: PackedInt32Array = StateData.bits_to_map(buffer.get_u8(), encoded_bits)
 	var decoded_data: Array = []
 	for i in decoded_map:
-		@warning_ignore("incompatible_ternary")
-		var val: Variant = buffer.get_u8() if i == STATE else buffer.get_half()
-		if typeof(val) == TYPE_FLOAT:
-			var step = 0.1
-			## Round decoded float values to the nearest multiple of step
-			val = snappedf(val, step)
+		var val: Variant = value_from_bytes(buffer, i)
 		decoded_data.append(val)
 	
 	return StateData.new(decoded_data, decoded_map, encoded_bits)
+
+static func value_from_bytes(buffer: StreamPeerBuffer, index: int) -> Variant:
+	@warning_ignore("incompatible_ternary")
+	var val: Variant = buffer.get_u8() if index == STATE else buffer.get_half()
+	if typeof(val) == TYPE_FLOAT:
+		var step = 0.1
+		## Round decoded float values to the nearest multiple of step
+		val = snappedf(val, step)
+	return val
 
 ## Converts [int]-bitstring into a [PackedInt32Array] with data indicies.
 static func bits_to_map(n: int, bit_count: int) -> PackedInt32Array:

--- a/StateData.gd
+++ b/StateData.gd
@@ -7,11 +7,10 @@ class_name StateData
 ## by updating only values that have changed, a "map" 
 ## value is used to indicate which attributes the provided 
 ## values correspond to.
-##
+
 # Byte array structure:
-#   Values:    [map, state, val_1, val_2, val_3]
-#   Types:     [uint8, uint8, float16, float16, float16]
-#   Max size:  64 bits
+#   Values:    [map, state, val_1, val_2, ..., val_n]
+#   Types:     [uint8, uint8, float16, float16, ...,  float16]
 #
 # The map is a bitstring (array of 0s and 1s) where each position 
 # corresponds to an index in the data array:

--- a/StateData2D.gd
+++ b/StateData2D.gd
@@ -1,10 +1,18 @@
 class_name StateData2D
 extends StateData
+## 2D implementation of the [StateData] class.
+##
+## [StateData2D] efficiently encodes 2-dimensional position 
+## and rotation as well as state as a [PackedByteArray] for 
+## sending it over the network with as little size as possible.
 
+# Value indicies
 const POS_X = 1
 const POS_Y = 2
 const ROT = 3
 
+## Amount of bits used to represent [member _map]. Equivalent 
+## to the maximum possible values which can be encoded into [member _map].
 const ENCODED_BITS = 4
 
 func _init(data: Array = [], map: PackedInt32Array = []) -> void:

--- a/StateData3D.gd
+++ b/StateData3D.gd
@@ -1,24 +1,22 @@
 class_name StateData3D
 extends StateData
-## StateData3D is an efficiently data structure which
-## encodes 3-dimensional position and rotation as well as state for sending
-## it over the network with as little size as possible.
-##
-## To save bandwidth, only values that changed should be
-## updated. This requires a map value which determines
-## to which attribute each values should be mapped to.
-##
-## Byte array structure:
-## values:		[map, pos_x, pos_y, pos_z, rot_x, rot_y, rot_z, state]
-## datatypes: 	[uint8, float16, float16, float16, float16, float16, float16, uint8]
-## max size: 112 bits
+## 3D implementation of the [StateData] class.
+## 
+## [StateData3D] efficiently encodes 3-dimensional position 
+## and rotation as well as state as a [PackedByteArray] for 
+## sending it over the network with as little size as possible.
 
-## Map bit structure:
-## Value 1 if data contains value for that index, 0 if otherwise
-## [POSX, POSY, POSZ, ROTX, ROTY, ROTZ, STATE]
-## Example: [0, 1, 0, 0, 0, 0, 1] -> Only contains POSY and STATE data
+# Byte array structure:
+# values:		[map, pos_x, pos_y, pos_z, rot_x, rot_y, rot_z, state]
+# datatypes: 	[uint8, float16, float16, float16, float16, float16, float16, uint8]
+# max size: 112 bits
 
-## Value indicies
+# Map bit structure:
+# Value 1 if data contains value for that index, 0 if otherwise
+# [POSX, POSY, POSZ, ROTX, ROTY, ROTZ, STATE]
+# Example: [0, 1, 0, 0, 0, 0, 1] -> Only contains POSY and STATE data
+
+# Value indicies
 const POS_X = 1
 const POS_Y = 2
 const POS_Z = 3
@@ -26,7 +24,8 @@ const ROT_X = 4
 const ROT_Y = 5
 const ROT_Z = 6
 
-## Maximum possible values encoded in map
+## Amount of bits used to represent [member _map]. Equivalent 
+## to the maximum possible values which can be encoded into [member _map].
 const ENCODED_BITS = 8
 
 func _init(data: Array = [], map: PackedInt32Array = []) -> void:

--- a/UnitTests.gd
+++ b/UnitTests.gd
@@ -1,28 +1,34 @@
 extends Node
 
+## Runs unit tests sequentially.
 func _ready() -> void:
 	test_map_conversion()
 	test_map_conversion([3])
 	test_map_conversion([1, 2])
-	print("Map conversion tests sucessful!")
+	print("Map conversion tests successful!")
 	
 	test_state_data_conversion()
 	test_state_data_conversion([4, 0.1, 12.6], [0, 1, 2])
 	test_state_data_conversion([0], [3])
 	test_state_data_conversion([6.8], [2])
-	print("StateData conversion tests sucessful!")
+	print("StateData conversion tests successful!")
 	
 	test_state_data_3d_conversion()
 	test_state_data_3d_conversion([5, 4.5, 78.2, 12.9], [0, 2, 4, 6])
 	test_state_data_3d_conversion([1.2, 41.5, 8.2, 52.9], [1, 2, 5, 6])
-	print("StateData3D conversion tests sucessful!")
+	print("StateData3D conversion tests successful!")
+	
+	test_batch_state_data()
+	print("BatchStateData tests successful")
 
+## Tests the conversion of the map [Array] to a bit-string as an [int].
 func test_map_conversion(map: PackedInt32Array = [0, 1, 2, 3]):
 	var sdata = StateData.new([5.7, 13.5, 0.8, 12.0], map)
 	var bits = sdata.map_to_bits()
 	var converted_map = StateData.bits_to_map(bits, 4)
 	assert(map == converted_map)
 
+## Tests the conversion of [StateData] objects to PackedByteArrays and vice versa.
 func test_state_data_conversion(data: Array = [5, 3.6, 5.5], map: PackedInt32Array = [0, 2, 3]):
 	var sdata = StateData.new(data, map)
 	var bytes = sdata.to_bytes()
@@ -33,6 +39,7 @@ func test_state_data_conversion(data: Array = [5, 3.6, 5.5], map: PackedInt32Arr
 		assert(snappedf(from_bytes.get_data()[i], step) == snappedf(data[i], step))
 	assert(from_bytes.get_map() == map)
 
+## Tests the conversion of [StateData3D] objects to PackedByteArrays and vice versa.
 func test_state_data_3d_conversion(data: Array = [5, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6], map: PackedInt32Array = [0, 1, 2, 3, 4, 5, 6]):
 	var sdata = StateData3D.new(data, map)
 	var bytes = sdata.to_bytes()
@@ -42,3 +49,18 @@ func test_state_data_3d_conversion(data: Array = [5, 0.1, 0.2, 0.3, 0.4, 0.5, 0.
 	for i in range(data.size()):
 		assert(snappedf(from_bytes.get_data()[i], step) == snappedf(data[i], step))
 	assert(from_bytes.get_map() == map)
+
+## Tests the conversion of [BatchStateData] objects to PackedByteArrays and vice versa.
+func test_batch_state_data():
+	var sdata1 = StateData.new([2.5, 6.7, 4.2], [1, 2, 3])
+	var sdata2 = StateData.new([0, 1.5], [0, 1])
+	var sdata3 = StateData.new([7, 37.9], [0, 2])
+	
+	var batch1 = BatchStateData.new({5:sdata1, 7:sdata2, 512:sdata3})
+	var batch1_bytes = batch1.to_bytes()
+	var batch1_decoded = BatchStateData.from_bytes(batch1_bytes)
+	
+	assert(batch1.get_data().size() == batch1_decoded.get_data().size())
+	
+	for key in batch1.get_data().keys():
+		assert(batch1.get_data()[key].equals(batch1_decoded.get_data()[key]))


### PR DESCRIPTION
This PR introduces the new `BatchStateData` class, which provides a way to store multiple `StateData` objects efficiently. Additionally, extensions of `BatchStateData` specifically `BatchStateData2D` and `BatchStateData3D` were added as examples for 2D and 3D use cases, respectively. It updates the benchmark scenes with addable units and the option between batching data or not.